### PR TITLE
[NEEDS ♥]: Update LibraryIQ Export to Include Aged Circulations with LEFT JOIN on User Table

### DIFF
--- a/extract_libraryiq.pl
+++ b/extract_libraryiq.pl
@@ -270,7 +270,7 @@ sub getCircIDs {
     SELECT acirc.id
     FROM
     action.all_circulation acirc
-    JOIN actor.usr au ON (acirc.usr=au.id)
+    LEFT JOIN actor.usr au ON (acirc.usr=au.id)
     JOIN asset.copy ac ON (ac.id=acirc.target_copy)
     JOIN asset.call_number acn on(acn.id=ac.call_number AND NOT ac.deleted AND NOT acn.deleted)
     WHERE
@@ -928,7 +928,7 @@ splitter
               JOIN asset.copy ac ON (ac.id=acirc.target_copy)
               JOIN asset.call_number acn ON (acn.id=ac.call_number AND NOT ac.deleted AND NOT acn.deleted)
               LEFT JOIN asset.copy_location acl ON (acl.id=ac.location)
-              JOIN actor.usr au ON (acirc.usr=au.id)
+              LEFT JOIN actor.usr au ON (acirc.usr=au.id)
               JOIN actor.org_unit aou_circ ON (acirc.circ_lib=aou_circ.id)
               WHERE
               acirc.id=cid;


### PR DESCRIPTION
This pull request addresses an issue where aged circulations were excluded from the LibraryIQ data extracts due to `NULL` values in the `usr` field of the `action.all_circulation` view. The original query used a `JOIN` with the `actor.usr` table, which excluded circulations with no associated user data. Switching to a `LEFT JOIN` ensures these records are included, providing a more complete circulation history.

The query may return significantly larger results due to the inclusion of all aged circulations, which could affect performance or processing times. We're worried about the impact of this and have not deployed it to production yet.

@bmagic007 
- I have tested parts of the updated SQL but not the script as a whole.
  - Specifically, I tested lines 914-934 and found the circulation count now matched what is displayed in Evergreen.
- Do you have suggestions for testing the performance and dataset size with this new query?
- Are there any concerns about including aged circulations that we should address before approval?